### PR TITLE
Fix card type helper name

### DIFF
--- a/telco_gpt/app/cards.py
+++ b/telco_gpt/app/cards.py
@@ -42,7 +42,10 @@ Return exactly five bullets
 
  """
 
-def dete_card_type(q:str)->str:
-    if _RGX_DEF.search(q): return CARD_DEF
-    if _RGX_TRB.search(q): return CARD_TRB
-    return CARD_DES 
+def detect_card_type(q: str) -> str:
+    """Return the appropriate response card for the given query."""
+    if _RGX_DEF.search(q):
+        return CARD_DEF
+    if _RGX_TRB.search(q):
+        return CARD_TRB
+    return CARD_DES

--- a/telco_gpt/app/routes.py
+++ b/telco_gpt/app/routes.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, request, jsonify, render_template
 from openai import AzureOpenAI, APIError, RateLimitError
 import os, redis, json, logging, time
-from .cards import dete_card_type
+from .cards import detect_card_type
 from .prompt_builder import build_prompt
 from .validator import validate_reply
 bp = Blueprint("api",__name__)
@@ -27,7 +27,7 @@ def chat():
         return jsonify({"Error":"empty message"}),4000000000
     
     hist = []  #rdb.lrange("chat",0,-1)
-    card = dete_card_type(msg.lower().strip())
+    card = detect_card_type(msg.lower().strip())
     prompt = build_prompt(card, hist, msg)
 
     try:


### PR DESCRIPTION
## Summary
- rename `dete_card_type` to `detect_card_type`
- update imports and calls in routes
- add short docstring to the helper

## Testing
- `python -m py_compile telco_gpt/app/cards.py telco_gpt/app/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_684abe58f0d8832ebff59804eecc940c